### PR TITLE
set java version

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,6 +2,7 @@ name: biojava-notebooks
 channels:
   - conda-forge
 dependencies:
+  - openjdk=8.0.152
   - beakerx
   - ipywidgets
   - matplotlib


### PR DESCRIPTION
BeakerX has problems with Java 11 (e.g., code hangs). Downgrading to Java 8 for now.